### PR TITLE
Add Firebase workspace task radar app

### DIFF
--- a/.firebaserc
+++ b/.firebaserc
@@ -1,0 +1,5 @@
+{
+  "projects": {
+    "default": "YOUR_FIREBASE_PROJECT_ID"
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,12 @@
+node_modules
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+functions/lib
+functions/node_modules
+web/node_modules
+web/dist
+.DS_Store
+.firebase
+firestore-debug.log
+ui-debug.log

--- a/README.md
+++ b/README.md
@@ -1,1 +1,126 @@
-# codextest
+# Workspace Task Radar
+
+Workspace Task Radar is a Firebase-ready application that aggregates assignments made to you across Google Workspace products (Tasks, Docs comments, Google Chat spaces, and Calendar). It exposes a Firebase Cloud Function that collates the data with Google APIs and a lightweight React dashboard deployed with Firebase Hosting.
+
+## Repository structure
+
+```
+├── firebase.json            # Firebase Hosting + Functions configuration
+├── .firebaserc              # Placeholder for your Firebase project id
+├── functions/               # Firebase Functions source (TypeScript)
+│   ├── src/
+│   │   ├── providers/       # Connectors for Google Workspace surfaces
+│   │   ├── config.ts        # Loads service account configuration
+│   │   ├── googleAuth.ts    # Creates a delegated auth client
+│   │   ├── index.ts         # HTTPS function entrypoint
+│   │   ├── summary.ts       # Task summarisation helpers
+│   │   └── tasksAggregator.ts
+│   └── package.json         # Functions dependencies
+└── web/                     # React single page app served by Firebase Hosting
+    ├── src/
+    │   ├── App.tsx          # Dashboard UI
+    │   ├── main.tsx         # React bootstrap
+    │   └── styles.css       # Styling
+    └── package.json         # Front-end dependencies
+```
+
+## Prerequisites
+
+1. **Firebase CLI** – Install via `npm install -g firebase-tools`.
+2. **Node.js 18+** – Both the Firebase functions and Vite front-end target Node 18.
+3. **Google Workspace admin access** – You need permission to create a service account and enable domain-wide delegation.
+4. **Google Cloud project linked to Firebase.** Create or reuse a Firebase project and link it to the same Google Cloud project.
+
+## Google Workspace configuration
+
+1. **Create a service account** in Google Cloud and enable *domain-wide delegation*.
+2. Download the JSON key and capture the following values:
+   - `client_email`
+   - `private_key`
+3. **Authorize the service account scopes** in the Workspace Admin console → *Security → Access and data control → API controls → Domain-wide delegation*. Add a new client using the service account client ID with these scopes:
+   - `https://www.googleapis.com/auth/tasks.readonly`
+   - `https://www.googleapis.com/auth/drive.readonly`
+   - `https://www.googleapis.com/auth/chat.tasks.readonly`
+   - `https://www.googleapis.com/auth/calendar.readonly`
+4. Decide which Workspace user the service account should impersonate (this is the default user whose tasks will be fetched when none is provided by the dashboard).
+
+## Firebase environment setup
+
+```bash
+# Authenticate with Firebase
+firebase login
+
+# Set your Firebase project (replace with your project ID)
+firebase use your-firebase-project-id
+
+# Configure secret values for the Cloud Function
+firebase functions:config:set \
+  google.service_account_email="service-account@project.iam.gserviceaccount.com" \
+  google.private_key="-----BEGIN PRIVATE KEY-----\n...\n-----END PRIVATE KEY-----\n" \
+  google.workspace_user="user@your-domain.com"
+
+# (Optional) inspect the stored config
+firebase functions:config:get
+```
+
+> 💡 The private key must preserve line breaks. Surrounding the value in quotes and replacing newlines with `\n` (as shown above) is the recommended approach.
+
+## Local development
+
+```bash
+# Install dependencies
+npm install --prefix functions
+npm install --prefix web
+
+# Build the web app for local hosting
+npm run build --prefix web
+
+# Start the Firebase emulators (Functions + Hosting)
+firebase emulators:start --only functions,hosting
+```
+
+The Hosting emulator serves the built React UI from `web/dist` and proxies `/api/tasks` to the local Cloud Function.
+
+If you prefer to iterate with the Vite dev server (`npm run dev --prefix web`), set `VITE_API_BASE` in a `.env` file so the front-end knows where to reach the emulator function, for example `VITE_API_BASE=http://localhost:5001/your-firebase-project-id/us-central1`.
+
+## Deployment workflow
+
+```bash
+# Build the front-end
+npm run build --prefix web
+
+# Deploy both hosting and functions
+firebase deploy --only hosting,functions
+```
+
+During deployment Firebase uploads the bundled dashboard from `web/dist` and the compiled Cloud Function from `functions/lib`.
+
+## Using the dashboard
+
+1. Visit your Firebase Hosting URL.
+2. Provide the email address you want to impersonate (it must be within your Workspace domain and have granted the service account access via domain-wide delegation).
+3. Click **Fetch tasks**.
+4. The dashboard displays:
+   - Total tasks, overdue items, and tasks due within 3 days.
+   - A breakdown by source (Tasks, Docs, Chat, Calendar).
+   - A detailed list with links back to the originating Workspace surface.
+   - Any provider-level errors (for example, if Chat tasks are disabled).
+
+You can also pass `?userEmail=user@your-domain.com` in the URL to pre-load a specific account.
+
+## Extending providers
+
+The connectors live in `functions/src/providers`. Each module returns an array of `WorkspaceTask` objects. To onboard more sources (e.g., Gmail assigned emails or third-party integrations) add a new provider module and include it in `aggregateWorkspaceTasks`.
+
+## Troubleshooting
+
+- **403/insufficient permissions** – Confirm the service account has domain-wide delegation and the necessary scopes.
+- **No Chat tasks returned** – The Google Chat Tasks API is rolling out gradually. Ensure the API is enabled and the user has access to space tasks.
+- **Docs assignments missing** – The connector parses unresolved comment threads that mention your email. Ensure collaborators used the built-in “Assign” feature so the email address is embedded in the HTML content.
+- **Calendar tasks** – These are upcoming events where your attendee status is `needsAction`. Accepting the event marks it complete.
+
+## Security considerations
+
+- Store credentials in Firebase Functions config or Secret Manager – never commit them.
+- Restrict who can trigger the Cloud Function via Firebase Hosting access controls or Identity Platform if exposing beyond internal use.
+- Consider enabling Firebase App Check if you later build a mobile client.

--- a/firebase.json
+++ b/firebase.json
@@ -1,0 +1,24 @@
+{
+  "functions": {
+    "source": "functions",
+    "runtime": "nodejs18"
+  },
+  "hosting": {
+    "public": "web/dist",
+    "ignore": [
+      "firebase.json",
+      "**/.*",
+      "**/node_modules/**"
+    ],
+    "rewrites": [
+      {
+        "source": "/api/tasks",
+        "function": "getWorkspaceTasks"
+      },
+      {
+        "source": "**",
+        "destination": "/index.html"
+      }
+    ]
+  }
+}

--- a/functions/package.json
+++ b/functions/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "workspace-task-aggregator-functions",
+  "version": "1.0.0",
+  "private": true,
+  "engines": {
+    "node": "18"
+  },
+  "scripts": {
+    "build": "tsc",
+    "serve": "npm run build && firebase emulators:start --only functions",
+    "deploy": "npm run build && firebase deploy --only functions"
+  },
+  "main": "lib/index.js",
+  "dependencies": {
+    "cors": "^2.8.5",
+    "firebase-admin": "^11.10.1",
+    "firebase-functions": "^4.4.1",
+    "googleapis": "^131.0.0"
+  },
+  "devDependencies": {
+    "@types/cors": "^2.8.13",
+    "@types/node": "^18.19.24",
+    "typescript": "^5.4.5"
+  }
+}

--- a/functions/src/config.ts
+++ b/functions/src/config.ts
@@ -1,0 +1,32 @@
+import * as functions from 'firebase-functions';
+
+type Config = {
+  serviceAccountEmail: string;
+  privateKey: string;
+  delegatedUser: string;
+};
+
+const cached: Partial<Config> = {};
+
+export function getGoogleWorkspaceConfig(): Config {
+  if (cached.serviceAccountEmail && cached.privateKey && cached.delegatedUser) {
+    return cached as Config;
+  }
+
+  const config = functions.config();
+  const serviceAccountEmail = config?.google?.service_account_email;
+  const privateKey = config?.google?.private_key;
+  const delegatedUser = config?.google?.workspace_user;
+
+  if (!serviceAccountEmail || !privateKey || !delegatedUser) {
+    throw new Error(
+      'Missing Google Workspace configuration. Set google.service_account_email, google.private_key, and google.workspace_user with "firebase functions:config:set".'
+    );
+  }
+
+  cached.serviceAccountEmail = serviceAccountEmail;
+  cached.privateKey = privateKey.replace(/\\n/g, '\n');
+  cached.delegatedUser = delegatedUser;
+
+  return cached as Config;
+}

--- a/functions/src/googleAuth.ts
+++ b/functions/src/googleAuth.ts
@@ -1,0 +1,22 @@
+import { google } from 'googleapis';
+import { getGoogleWorkspaceConfig } from './config';
+
+const SCOPES = [
+  'https://www.googleapis.com/auth/tasks.readonly',
+  'https://www.googleapis.com/auth/drive.readonly',
+  'https://www.googleapis.com/auth/chat.tasks.readonly',
+  'https://www.googleapis.com/auth/calendar.readonly'
+];
+
+export async function getGoogleAuth() {
+  const { serviceAccountEmail, privateKey, delegatedUser } = getGoogleWorkspaceConfig();
+  const client = new google.auth.JWT({
+    email: serviceAccountEmail,
+    key: privateKey,
+    scopes: SCOPES,
+    subject: delegatedUser
+  });
+
+  await client.authorize();
+  return client;
+}

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -1,0 +1,41 @@
+import * as admin from 'firebase-admin';
+import * as functions from 'firebase-functions';
+import cors from 'cors';
+import { aggregateWorkspaceTasks } from './tasksAggregator';
+import { getGoogleWorkspaceConfig } from './config';
+
+admin.initializeApp();
+
+const corsHandler = cors({ origin: true });
+
+export const getWorkspaceTasks = functions.region('us-central1').https.onRequest((req, res) => {
+  corsHandler(req, res, async () => {
+    if (req.method === 'OPTIONS') {
+      res.set('Access-Control-Allow-Methods', 'GET, POST');
+      res.set('Access-Control-Allow-Headers', 'Content-Type');
+      res.status(204).send('');
+      return;
+    }
+
+    if (req.method !== 'GET' && req.method !== 'POST') {
+      res.status(405).json({ error: 'Method not allowed' });
+      return;
+    }
+
+    try {
+      const { delegatedUser } = getGoogleWorkspaceConfig();
+      const userEmail =
+        (typeof req.query.userEmail === 'string' && req.query.userEmail.trim()) ||
+        (req.body && typeof req.body.userEmail === 'string' && req.body.userEmail.trim()) ||
+        delegatedUser;
+
+      const data = await aggregateWorkspaceTasks(userEmail);
+      res.status(200).json({ userEmail, ...data });
+    } catch (error) {
+      functions.logger.error('Failed to aggregate workspace tasks', error);
+      res.status(500).json({
+        error: error instanceof Error ? error.message : 'Unknown error'
+      });
+    }
+  });
+});

--- a/functions/src/providers/googleCalendar.ts
+++ b/functions/src/providers/googleCalendar.ts
@@ -1,0 +1,53 @@
+import { google } from 'googleapis';
+import { WorkspaceTask } from '../types';
+
+type GoogleAuth = Awaited<ReturnType<typeof import('../googleAuth')['getGoogleAuth']>>;
+
+export async function fetchGoogleCalendarTasks(
+  auth: GoogleAuth,
+  userEmail: string
+): Promise<WorkspaceTask[]> {
+  const calendar = google.calendar({ version: 'v3', auth });
+  const now = new Date();
+  const timeMin = now.toISOString();
+  const timeMax = new Date(now.getTime() + 1000 * 60 * 60 * 24 * 30).toISOString();
+
+  const response = await calendar.events.list({
+    calendarId: 'primary',
+    timeMin,
+    timeMax,
+    singleEvents: true,
+    orderBy: 'startTime',
+    maxResults: 100
+  });
+
+  const events = response.data.items ?? [];
+  return events
+    .filter((event) => {
+      const attendees = event.attendees ?? [];
+      return attendees.some(
+        (attendee) =>
+          attendee.email?.toLowerCase() === userEmail.toLowerCase() &&
+          attendee.responseStatus === 'needsAction'
+      );
+    })
+    .map<WorkspaceTask>((event) => ({
+      id: event.id ?? '',
+      title: event.summary ?? 'Calendar task',
+      source: 'Google Calendar Task',
+      link: event.htmlLink ?? undefined,
+      due:
+        event.end?.dateTime ??
+        (event.end?.date ? new Date(event.end.date).toISOString() : undefined),
+      createdTime: event.created ?? undefined,
+      updatedTime: event.updated ?? undefined,
+      status: event.status ?? undefined,
+      description: event.description ?? undefined,
+      metadata: {
+        organizer: event.organizer?.email,
+        start: event.start,
+        end: event.end
+      }
+    }))
+    .filter((task) => task.id);
+}

--- a/functions/src/providers/googleChat.ts
+++ b/functions/src/providers/googleChat.ts
@@ -1,0 +1,53 @@
+import { google } from 'googleapis';
+import { WorkspaceTask } from '../types';
+
+type GoogleAuth = Awaited<ReturnType<typeof import('../googleAuth')['getGoogleAuth']>>;
+
+export async function fetchGoogleChatTasks(
+  auth: GoogleAuth,
+  userEmail: string
+): Promise<WorkspaceTask[]> {
+  const chat = google.chat({ version: 'v1', auth });
+  const spacesResponse = await chat.spaces.list({ pageSize: 50 });
+  const spaces = spacesResponse.data.spaces ?? [];
+
+  const allTasks: WorkspaceTask[] = [];
+  for (const space of spaces) {
+    if (!space.name) continue;
+
+    try {
+      const tasksResponse = await (chat as any).spaces.tasks.list({
+        parent: space.name,
+        assignee: `users/${userEmail}`
+      });
+      const tasks = tasksResponse.data.tasks ?? [];
+      for (const task of tasks) {
+        if (!task.name) continue;
+        allTasks.push({
+          id: task.name,
+          title: task.title ?? 'Chat task',
+          source: 'Google Chat Task',
+          link: task.thread?.name ? `https://chat.google.com/${task.thread.name.replace('spaces/', '').replace('/threads/', '/')}` : undefined,
+          due: task.dueDateTime ?? undefined,
+          createdTime: task.createTime ?? undefined,
+          updatedTime: task.updateTime ?? undefined,
+          status: task.state,
+          description: task.description ?? undefined,
+          metadata: {
+            space: {
+              name: space.name,
+              displayName: space.displayName
+            },
+            assignee: task.assignee,
+            creator: task.creator
+          }
+        });
+      }
+    } catch (error) {
+      // Ignore spaces where the API is not enabled or permissions are missing.
+      continue;
+    }
+  }
+
+  return allTasks;
+}

--- a/functions/src/providers/googleDocs.ts
+++ b/functions/src/providers/googleDocs.ts
@@ -1,0 +1,75 @@
+import { google } from 'googleapis';
+import { WorkspaceTask } from '../types';
+
+type GoogleAuth = Awaited<ReturnType<typeof import('../googleAuth')['getGoogleAuth']>>;
+
+const DOCS_QUERY = "mimeType='application/vnd.google-apps.document' and trashed=false";
+
+function extractAssigneeEmails(htmlContent?: string): string[] {
+  if (!htmlContent) {
+    return [];
+  }
+
+  const matches = htmlContent.match(/data-user-email=\"([^\"]+)\"/g) ?? [];
+  return matches.map((match) => match.split('"')[1]).filter(Boolean);
+}
+
+export async function fetchGoogleDocsAssignments(
+  auth: GoogleAuth,
+  userEmail: string
+): Promise<WorkspaceTask[]> {
+  const drive = google.drive({ version: 'v3', auth });
+  const filesResponse = await drive.files.list({
+    q: DOCS_QUERY,
+    fields: 'files(id,name,webViewLink)',
+    orderBy: 'modifiedTime desc',
+    pageSize: 30
+  });
+
+  const files = filesResponse.data.files ?? [];
+  const tasks: WorkspaceTask[] = [];
+
+  for (const file of files) {
+    if (!file.id) continue;
+
+    const commentsResponse = await drive.comments.list({
+      fileId: file.id,
+      fields:
+        'comments(id,htmlContent,createdTime,modifiedTime,resolved,author(displayName,emailAddress),replies(id,htmlContent,createdTime,author(displayName,emailAddress),resolved))',
+      includeDeleted: false,
+      pageSize: 100
+    });
+
+    const comments = commentsResponse.data.comments ?? [];
+    for (const comment of comments) {
+      const commentAssignees = extractAssigneeEmails(comment.htmlContent);
+      const isAssigned = commentAssignees.includes(userEmail.toLowerCase());
+
+      const replies = comment.replies ?? [];
+      const replyAssignments = replies.flatMap((reply) => extractAssigneeEmails(reply.htmlContent));
+      const replyAssigned = replyAssignments.includes(userEmail.toLowerCase());
+
+      if ((isAssigned || replyAssigned) && !comment.resolved) {
+        tasks.push({
+          id: `${file.id}:${comment.id}`,
+          title: comment.htmlContent
+            ? comment.htmlContent.replace(/<[^>]+>/g, '').trim()
+            : 'Action item',
+          source: 'Google Docs Action Item',
+          link: file.webViewLink ?? undefined,
+          createdTime: comment.createdTime ?? undefined,
+          updatedTime: comment.modifiedTime ?? undefined,
+          status: comment.resolved ? 'completed' : 'open',
+          metadata: {
+            documentName: file.name,
+            commentId: comment.id,
+            assignedFromComment: isAssigned,
+            assignedFromReply: replyAssigned
+          }
+        });
+      }
+    }
+  }
+
+  return tasks;
+}

--- a/functions/src/providers/googleTasks.ts
+++ b/functions/src/providers/googleTasks.ts
@@ -1,0 +1,50 @@
+import { google } from 'googleapis';
+import { WorkspaceTask } from '../types';
+
+type GoogleAuth = Awaited<ReturnType<typeof import('../googleAuth')['getGoogleAuth']>>;
+
+const TASK_LINK_BASE = 'https://tasks.google.com/embed/list';
+
+export async function fetchGoogleTasks(auth: GoogleAuth): Promise<WorkspaceTask[]> {
+  const tasksClient = google.tasks({ version: 'v1', auth });
+  const tasklistsResponse = await tasksClient.tasklists.list({ maxResults: 50 });
+  const tasklists = tasklistsResponse.data.items ?? [];
+
+  const taskPromises = tasklists.map(async (list) => {
+    if (!list.id) {
+      return [] as WorkspaceTask[];
+    }
+
+    const tasksResponse = await tasksClient.tasks.list({
+      tasklist: list.id,
+      showCompleted: false,
+      showHidden: false,
+      maxResults: 200
+    });
+
+    const items = tasksResponse.data.items ?? [];
+    return items
+      .filter((task) => task.id && !task.deleted)
+      .map<WorkspaceTask>((task) => ({
+        id: `${list.id}:${task.id}`,
+        title: task.title ?? 'Untitled Task',
+        source: 'Google Tasks',
+        link: task.id
+          ? `${TASK_LINK_BASE}/${encodeURIComponent(list.id!)}?task=${encodeURIComponent(task.id)}`
+          : undefined,
+        due: task.due ?? undefined,
+        createdTime: task.updated ?? undefined,
+        updatedTime: task.updated ?? undefined,
+        status: task.status ?? undefined,
+        description: task.notes ?? undefined,
+        metadata: {
+          tasklist: list.title,
+          parentTaskId: task.parent,
+          position: task.position
+        }
+      }));
+  });
+
+  const tasks = (await Promise.all(taskPromises)).flat();
+  return tasks;
+}

--- a/functions/src/summary.ts
+++ b/functions/src/summary.ts
@@ -1,0 +1,38 @@
+import { TaskSummary, WorkspaceTask } from './types';
+
+const MILLISECONDS_IN_DAY = 1000 * 60 * 60 * 24;
+
+export function buildSummary(tasks: WorkspaceTask[]): TaskSummary {
+  const now = Date.now();
+  const bySource = {
+    'Google Tasks': 0,
+    'Google Docs Action Item': 0,
+    'Google Chat Task': 0,
+    'Google Calendar Task': 0
+  } as TaskSummary['bySource'];
+
+  let overdue = 0;
+  let dueSoon = 0;
+
+  tasks.forEach((task) => {
+    bySource[task.source] = (bySource[task.source] ?? 0) + 1;
+
+    if (task.due) {
+      const dueTime = Date.parse(task.due);
+      if (!Number.isNaN(dueTime)) {
+        if (dueTime < now) {
+          overdue += 1;
+        } else if (dueTime - now <= MILLISECONDS_IN_DAY * 3) {
+          dueSoon += 1;
+        }
+      }
+    }
+  });
+
+  return {
+    total: tasks.length,
+    bySource,
+    overdue,
+    dueSoon
+  };
+}

--- a/functions/src/tasksAggregator.ts
+++ b/functions/src/tasksAggregator.ts
@@ -1,0 +1,38 @@
+import { getGoogleAuth } from './googleAuth';
+import { fetchGoogleTasks } from './providers/googleTasks';
+import { fetchGoogleDocsAssignments } from './providers/googleDocs';
+import { fetchGoogleChatTasks } from './providers/googleChat';
+import { fetchGoogleCalendarTasks } from './providers/googleCalendar';
+import { buildSummary } from './summary';
+import { TaskAggregationResult, WorkspaceTask } from './types';
+
+export async function aggregateWorkspaceTasks(userEmail: string): Promise<TaskAggregationResult> {
+  const auth = await getGoogleAuth();
+  const results = await Promise.allSettled<WorkspaceTask[]>([
+    fetchGoogleTasks(auth),
+    fetchGoogleDocsAssignments(auth, userEmail),
+    fetchGoogleChatTasks(auth, userEmail),
+    fetchGoogleCalendarTasks(auth, userEmail)
+  ]);
+
+  const tasks: WorkspaceTask[] = [];
+  const errors: TaskAggregationResult['errors'] = [];
+
+  const providers = [
+    'Google Tasks',
+    'Google Docs Action Item',
+    'Google Chat Task',
+    'Google Calendar Task'
+  ] as const;
+
+  results.forEach((result, index) => {
+    if (result.status === 'fulfilled') {
+      tasks.push(...result.value);
+    } else {
+      errors.push({ provider: providers[index], message: result.reason instanceof Error ? result.reason.message : String(result.reason) });
+    }
+  });
+
+  const summary = buildSummary(tasks);
+  return { tasks, summary, errors };
+}

--- a/functions/src/types.ts
+++ b/functions/src/types.ts
@@ -1,0 +1,31 @@
+export type TaskSource =
+  | 'Google Tasks'
+  | 'Google Docs Action Item'
+  | 'Google Chat Task'
+  | 'Google Calendar Task';
+
+export interface WorkspaceTask {
+  id: string;
+  title: string;
+  source: TaskSource;
+  link?: string;
+  due?: string;
+  createdTime?: string;
+  updatedTime?: string;
+  status?: string;
+  description?: string;
+  metadata?: Record<string, unknown>;
+}
+
+export interface TaskSummary {
+  total: number;
+  bySource: Record<TaskSource, number>;
+  overdue: number;
+  dueSoon: number;
+}
+
+export interface TaskAggregationResult {
+  tasks: WorkspaceTask[];
+  summary: TaskSummary;
+  errors: { provider: TaskSource | 'Google Workspace'; message: string }[];
+}

--- a/functions/tsconfig.json
+++ b/functions/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "lib": ["es2020"],
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "noImplicitAny": false,
+    "outDir": "lib",
+    "sourceMap": true,
+    "target": "es2020",
+    "esModuleInterop": true,
+    "strict": true,
+    "skipLibCheck": true
+  },
+  "compileOnSave": true,
+  "include": ["src"]
+}

--- a/web/.env.example
+++ b/web/.env.example
@@ -1,0 +1,6 @@
+# Point the React app at a deployed Cloud Function or emulator instance
+# Example for Firebase emulator (replace PROJECT_ID accordingly):
+# VITE_API_BASE=http://localhost:5001/PROJECT_ID/us-central1
+
+# Leave blank to rely on Firebase Hosting rewrite to /api/tasks
+VITE_API_BASE=

--- a/web/index.html
+++ b/web/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Workspace Task Radar</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/web/package.json
+++ b/web/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "workspace-task-aggregator-web",
+  "private": true,
+  "version": "1.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc && vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "@types/react": "^18.2.21",
+    "@types/react-dom": "^18.2.7",
+    "@vitejs/plugin-react": "^4.2.1",
+    "typescript": "^5.4.5",
+    "vite": "^5.2.0"
+  }
+}

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,0 +1,246 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+
+interface WorkspaceTask {
+  id: string;
+  title: string;
+  source: string;
+  link?: string;
+  due?: string;
+  createdTime?: string;
+  updatedTime?: string;
+  status?: string;
+  description?: string;
+  metadata?: Record<string, unknown>;
+}
+
+interface TaskSummary {
+  total: number;
+  bySource: Record<string, number>;
+  overdue: number;
+  dueSoon: number;
+}
+
+interface AggregationResponse {
+  userEmail: string;
+  tasks: WorkspaceTask[];
+  summary: TaskSummary;
+  errors: { provider: string; message: string }[];
+}
+
+const API_BASE = import.meta.env.VITE_API_BASE ?? '';
+
+function formatDate(value?: string) {
+  if (!value) return '—';
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return '—';
+  return date.toLocaleString();
+}
+
+function formatSource(source: string) {
+  return source.replace(/Task$/i, '').trim();
+}
+
+export default function App() {
+  const [response, setResponse] = useState<AggregationResponse | null>(null);
+  const [userEmail, setUserEmail] = useState('');
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchTasks = useCallback(
+    async (email: string) => {
+      if (!email) {
+        setError('Please provide an email address to impersonate.');
+        return;
+      }
+
+      setLoading(true);
+      setError(null);
+      try {
+        const url = new URL(`${API_BASE}/api/tasks`, window.location.origin);
+        url.searchParams.set('userEmail', email);
+        const res = await fetch(url.toString(), {
+          headers: { 'Content-Type': 'application/json' }
+        });
+
+        if (!res.ok) {
+          const payload = await res.json().catch(() => ({}));
+          throw new Error(payload.error ?? 'Failed to fetch tasks');
+        }
+
+        const payload: AggregationResponse = await res.json();
+        setResponse(payload);
+      } catch (err) {
+        setError(err instanceof Error ? err.message : 'Unexpected error');
+      } finally {
+        setLoading(false);
+      }
+    },
+    []
+  );
+
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search);
+    const emailParam = params.get('userEmail');
+    if (emailParam) {
+      setUserEmail(emailParam);
+      fetchTasks(emailParam).catch(() => undefined);
+    }
+  }, [fetchTasks]);
+
+  const summaryCards = useMemo(() => {
+    const summary = response?.summary;
+    if (!summary) return [];
+    return [
+      { label: 'Total Tasks', value: summary.total.toString() },
+      { label: 'Overdue', value: summary.overdue.toString() },
+      { label: 'Due in 3 days', value: summary.dueSoon.toString() }
+    ];
+  }, [response]);
+
+  const sourceBreakdown = useMemo(() => {
+    const summary = response?.summary;
+    if (!summary) return [];
+    return Object.entries(summary.bySource).map(([source, value]) => ({
+      source,
+      value
+    }));
+  }, [response]);
+
+  const handleSubmit = useCallback(
+    (event: React.FormEvent<HTMLFormElement>) => {
+      event.preventDefault();
+      fetchTasks(userEmail.trim());
+    },
+    [fetchTasks, userEmail]
+  );
+
+  return (
+    <main>
+      <header>
+        <h1>Workspace Task Radar</h1>
+        <p>
+          Aggregate tasks assigned to you across Google Tasks, Docs, Chat, and Calendar, then
+          review progress with a unified dashboard.
+        </p>
+        <form onSubmit={handleSubmit} style={{ display: 'flex', gap: '0.75rem', flexWrap: 'wrap' }}>
+          <input
+            type="email"
+            placeholder="user@your-domain.com"
+            value={userEmail}
+            onChange={(event) => setUserEmail(event.target.value)}
+            required
+            style={{
+              flex: '1 1 260px',
+              padding: '0.75rem 1rem',
+              borderRadius: '999px',
+              border: '1px solid #cbd5f5',
+              fontSize: '1rem'
+            }}
+          />
+          <button
+            type="submit"
+            disabled={loading}
+            style={{
+              padding: '0.75rem 1.5rem',
+              borderRadius: '999px',
+              border: 'none',
+              background: '#2563eb',
+              color: '#fff',
+              fontSize: '1rem',
+              fontWeight: 600,
+              cursor: loading ? 'wait' : 'pointer'
+            }}
+          >
+            {loading ? 'Refreshing…' : 'Fetch tasks'}
+          </button>
+        </form>
+      </header>
+
+      {error ? (
+        <div className="error-box">
+          <strong>Unable to load tasks.</strong>
+          <p>{error}</p>
+        </div>
+      ) : null}
+
+      {response ? (
+        <>
+          <section>
+            <h2>Summary</h2>
+            <div className="summary-grid" style={{ marginTop: '1rem' }}>
+              {summaryCards.map((card) => (
+                <div key={card.label} className="summary-card">
+                  <h3>{card.label}</h3>
+                  <p>{card.value}</p>
+                </div>
+              ))}
+            </div>
+            <div style={{ marginTop: '1.5rem' }}>
+              <h3 style={{ marginBottom: '0.75rem' }}>By Source</h3>
+              <div className="summary-grid">
+                {sourceBreakdown.map((item) => (
+                  <div key={item.source} className="summary-card">
+                    <h3>{item.source}</h3>
+                    <p>{item.value}</p>
+                  </div>
+                ))}
+              </div>
+            </div>
+          </section>
+
+          {response.errors.length > 0 ? (
+            <section className="error-box" style={{ boxShadow: 'none' }}>
+              <h3 style={{ marginTop: 0 }}>Providers with issues</h3>
+              <ul>
+                {response.errors.map((issue) => (
+                  <li key={issue.provider}>
+                    <strong>{issue.provider}:</strong> {issue.message}
+                  </li>
+                ))}
+              </ul>
+            </section>
+          ) : null}
+
+          <section>
+            <h2 style={{ marginTop: 0 }}>Tasks</h2>
+            <div className="task-list" style={{ marginTop: '1.5rem' }}>
+              {response.tasks.length === 0 ? (
+                <p>No open tasks found for {response.userEmail}.</p>
+              ) : (
+                response.tasks.map((task) => (
+                  <article key={task.id} className="task-card">
+                    <div style={{ minWidth: 0 }}>
+                      <h4>{task.title}</h4>
+                      <div className="task-meta">
+                        <span className="badge">{formatSource(task.source)}</span>
+                        {task.due ? <span>Due {formatDate(task.due)}</span> : null}
+                        {task.metadata?.documentName ? (
+                          <span>Doc: {String(task.metadata.documentName)}</span>
+                        ) : null}
+                        {task.metadata?.space && typeof task.metadata.space === 'object' ? (
+                          <span>
+                            Space: {String((task.metadata.space as Record<string, unknown>).displayName ?? '')}
+                          </span>
+                        ) : null}
+                        {task.link ? (
+                          <a href={task.link} target="_blank" rel="noreferrer">
+                            Open source
+                          </a>
+                        ) : null}
+                      </div>
+                    </div>
+                    <span className="status-pill" data-state={task.status ?? 'open'}>
+                      {(task.status ?? 'open').replace(/_/g, ' ')}
+                    </span>
+                  </article>
+                ))
+              )}
+            </div>
+          </section>
+        </>
+      ) : !loading ? (
+        <p>Enter your email and click “Fetch tasks” to pull assignments.</p>
+      ) : null}
+    </main>
+  );
+}

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+import './styles.css';
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -1,0 +1,147 @@
+:root {
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  color: #1f2933;
+  background-color: #f8fafc;
+}
+
+body,
+html,
+#root {
+  margin: 0;
+  padding: 0;
+  min-height: 100%;
+}
+
+a {
+  color: #2563eb;
+}
+
+main {
+  max-width: 1100px;
+  margin: 0 auto;
+  padding: 2rem 1.5rem 3rem;
+}
+
+header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  margin-bottom: 2rem;
+}
+
+header h1 {
+  font-size: 2rem;
+  font-weight: 700;
+  margin: 0;
+}
+
+section {
+  background: white;
+  border-radius: 16px;
+  padding: 1.5rem;
+  box-shadow: 0 10px 30px -20px rgba(15, 23, 42, 0.4);
+  margin-bottom: 2rem;
+}
+
+.summary-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 1rem;
+}
+
+.summary-card {
+  background: #f1f5f9;
+  border-radius: 12px;
+  padding: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.summary-card h3 {
+  font-size: 0.875rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin: 0;
+}
+
+.summary-card p {
+  font-size: 1.75rem;
+  margin: 0;
+  font-weight: 700;
+}
+
+.task-list {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.task-card {
+  border: 1px solid #e2e8f0;
+  border-radius: 12px;
+  padding: 1rem;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 0.75rem;
+  align-items: center;
+}
+
+.task-card h4 {
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 600;
+}
+
+.task-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  font-size: 0.875rem;
+  color: #475569;
+}
+
+.badge {
+  background: #e0e7ff;
+  color: #3730a3;
+  border-radius: 999px;
+  padding: 0.25rem 0.75rem;
+  font-size: 0.75rem;
+  font-weight: 600;
+}
+
+.status-pill {
+  padding: 0.25rem 0.75rem;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  font-weight: 600;
+}
+
+.status-pill[data-state='open'] {
+  background: #fee2e2;
+  color: #991b1b;
+}
+
+.status-pill[data-state='completed'] {
+  background: #dcfce7;
+  color: #166534;
+}
+
+.error-box {
+  border-radius: 12px;
+  border: 1px solid #fecaca;
+  background: #fef2f2;
+  padding: 1rem;
+  margin-bottom: 1.5rem;
+}
+
+@media (max-width: 600px) {
+  section {
+    padding: 1.25rem;
+  }
+
+  .task-card {
+    grid-template-columns: 1fr;
+  }
+}

--- a/web/tsconfig.json
+++ b/web/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "useDefineForClassFields": true,
+    "lib": ["DOM", "DOM.Iterable", "ESNext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "esModuleInterop": false,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx"
+  },
+  "include": ["src"],
+  "references": [{ "path": "./tsconfig.node.json" }]
+}

--- a/web/tsconfig.node.json
+++ b/web/tsconfig.node.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "allowSyntheticDefaultImports": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  build: {
+    outDir: 'dist',
+    sourcemap: true
+  }
+});


### PR DESCRIPTION
## Summary
- add Firebase Cloud Function that aggregates Google Workspace tasks from Tasks, Docs comments, Chat spaces, and Calendar
- scaffold React dashboard for Firebase Hosting to display the unified task list and summary metrics
- document Firebase and Google Workspace setup plus local development workflow

## Testing
- ⚠️ `npm install --prefix functions` *(fails in CI environment: 403 Forbidden from registry)*

------
https://chatgpt.com/codex/tasks/task_e_68df999574dc8332a36b5617fab90b62